### PR TITLE
Use provided crypto in chains

### DIFF
--- a/options.go
+++ b/options.go
@@ -45,6 +45,9 @@ func WithCrypto(c Crypto) option {
 			return fmt.Errorf("Crypto mustn't be nil")
 		}
 		s.Crypto = c
+		s.RootCh.Crypto = c
+		s.SendCh.Crypto = c
+		s.RecvCh.Crypto = c
 		return nil
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -82,6 +82,9 @@ func TestWithCrypto_OK(t *testing.T) {
 
 	// Assert.
 	require.Nil(t, err)
+	require.NotNil(t, s.RootCh.Crypto)
+	require.NotNil(t, s.SendCh.Crypto)
+	require.NotNil(t, s.RecvCh.Crypto)
 	require.NotNil(t, s.Crypto)
 }
 


### PR DESCRIPTION
The code was not setting the provided crypto in the chains, so it would use the one provided for encryption but not for the chains, using the `DefaultCrypto` implementation and mixing the 2.
