### PR TITLE
Allow to store and load sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/tiabc/doubleratchet"
+	"github.com/status-im/doubleratchet"
 )
 
 func main() {
@@ -80,19 +80,23 @@ func main() {
 	}
 
 	// Bob MUST be created with the shared secret and a DH key pair.
-	bob, err := doubleratchet.New(sk, keyPair)
+	bob, err := doubleratchet.New([]byte("bob-session-id"), sk, keyPair, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Alice MUST be created with the shared secret and Bob's public key.
-	alice, err := doubleratchet.NewWithRemoteKey(sk, keyPair.PublicKey())
+	alice, err := doubleratchet.NewWithRemoteKey([]byte("alice-session-id"), sk, keyPair.PublicKey(), nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Alice can now encrypt messages under the Double Ratchet session.
-	m := alice.RatchetEncrypt([]byte("Hi Bob!"), nil)
+	m, err := alice.RatchetEncrypt([]byte("Hi Bob!"), nil)
+
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// Which Bob can decrypt.
 	plaintext, err := bob.RatchetDecrypt(m, nil)

--- a/options.go
+++ b/options.go
@@ -3,11 +3,11 @@ package doubleratchet
 import "fmt"
 
 // option is a constructor option.
-type option func(*state) error
+type option func(*State) error
 
 // WithMaxSkip specifies the maximum number of skipped message in a single chain.
 func WithMaxSkip(n int) option {
-	return func(s *state) error {
+	return func(s *State) error {
 		if n < 0 {
 			return fmt.Errorf("n must be non-negative")
 		}
@@ -18,7 +18,7 @@ func WithMaxSkip(n int) option {
 
 // WithMaxKeep specifies the maximum number of ratchet steps before a message is deleted.
 func WithMaxKeep(n int) option {
-	return func(s *state) error {
+	return func(s *State) error {
 		if n < 0 {
 			return fmt.Errorf("n must be non-negative")
 		}
@@ -29,7 +29,7 @@ func WithMaxKeep(n int) option {
 
 // WithKeysStorage replaces the default keys storage with the specified.
 func WithKeysStorage(ks KeysStorage) option {
-	return func(s *state) error {
+	return func(s *State) error {
 		if ks == nil {
 			return fmt.Errorf("KeysStorage mustn't be nil")
 		}
@@ -40,7 +40,7 @@ func WithKeysStorage(ks KeysStorage) option {
 
 // WithCrypto replaces the default cryptographic supplement with the specified.
 func WithCrypto(c Crypto) option {
-	return func(s *state) error {
+	return func(s *State) error {
 		if c == nil {
 			return fmt.Errorf("Crypto mustn't be nil")
 		}

--- a/options_test.go
+++ b/options_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestWithMaxSkip_OK(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithMaxSkip(150)(&s)
@@ -19,7 +19,7 @@ func TestWithMaxSkip_OK(t *testing.T) {
 
 func TestWithMaxSkip_Negative(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithMaxSkip(-150)(&s)
@@ -29,7 +29,7 @@ func TestWithMaxSkip_Negative(t *testing.T) {
 }
 func TestWithMaxKeep_OK(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithMaxKeep(150)(&s)
@@ -41,7 +41,7 @@ func TestWithMaxKeep_OK(t *testing.T) {
 
 func TestWithMaxKeep_Negative(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithMaxKeep(-150)(&s)
@@ -52,7 +52,7 @@ func TestWithMaxKeep_Negative(t *testing.T) {
 
 func TestWithKeysStorage_OK(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithKeysStorage(&KeysStorageInMemory{})(&s)
@@ -64,7 +64,7 @@ func TestWithKeysStorage_OK(t *testing.T) {
 
 func TestWithKeysStorage_Nil(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithKeysStorage(nil)(&s)
@@ -75,7 +75,7 @@ func TestWithKeysStorage_Nil(t *testing.T) {
 
 func TestWithCrypto_OK(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithCrypto(DefaultCrypto{})(&s)
@@ -90,7 +90,7 @@ func TestWithCrypto_OK(t *testing.T) {
 
 func TestWithCrypto_Nil(t *testing.T) {
 	// Arrange.
-	s := state{}
+	s := State{}
 
 	// Act.
 	err := WithCrypto(nil)(&s)

--- a/session_he.go
+++ b/session_he.go
@@ -13,7 +13,7 @@ type SessionHE interface {
 }
 
 type sessionHE struct {
-	state
+	State
 }
 
 // NewHE creates session with the shared keys.
@@ -79,7 +79,7 @@ func (s *sessionHE) RatchetDecrypt(m MessageHE, ad []byte) ([]byte, error) {
 
 	var (
 		// All changes must be applied on a different session object, so that this session won't be modified nor left in a dirty session.
-		sc state = s.state
+		sc State = s.State
 
 		skippedKeys1 []skippedKey
 		skippedKeys2 []skippedKey

--- a/session_storage.go
+++ b/session_storage.go
@@ -1,0 +1,9 @@
+package doubleratchet
+
+type SessionStorage interface {
+	// Get returns a message key by the given key and message number.
+	Save(id []byte, state *State) error
+
+	// Put saves the given mk under the specified key and msgNum.
+	Load(id []byte) (*State, error)
+}

--- a/session_storage.go
+++ b/session_storage.go
@@ -1,9 +1,9 @@
 package doubleratchet
 
 type SessionStorage interface {
-	// Get returns a message key by the given key and message number.
+	// Save state keyed by id
 	Save(id []byte, state *State) error
 
-	// Put saves the given mk under the specified key and msgNum.
+	// Load state by id
 	Load(id []byte) (*State, error)
 }

--- a/state.go
+++ b/state.go
@@ -9,7 +9,7 @@ import (
 )
 
 // The double ratchet state.
-type state struct {
+type State struct {
 	Crypto Crypto
 
 	// DH Ratchet public key (the remote key).
@@ -52,38 +52,49 @@ type state struct {
 	DeleteKeys map[uint]Key
 }
 
-func newState(sharedKey Key, opts ...option) (state, error) {
-	if sharedKey == [32]byte{} {
-		return state{}, fmt.Errorf("sharedKey mustn't be empty")
-	}
-	var (
-		c = DefaultCrypto{}
-		s = state{
-			DHs:    dhPair{},
-			Crypto: c,
-			RootCh: kdfRootChain{CK: sharedKey, Crypto: c},
-			// Populate CKs and CKr with sharedKey so that both parties could send and receive
-			// messages from the very beginning.
-			SendCh:     kdfChain{CK: sharedKey, Crypto: c},
-			RecvCh:     kdfChain{CK: sharedKey, Crypto: c},
-			MkSkipped:  &KeysStorageInMemory{},
-			MaxSkip:    1000,
-			MaxKeep:    100,
-			DeleteKeys: make(map[uint]Key),
-		}
-	)
+func DefaultState(sharedKey Key) State {
+	c := DefaultCrypto{}
 
+	return State{
+		DHs:    dhPair{},
+		Crypto: c,
+		RootCh: kdfRootChain{CK: sharedKey, Crypto: c},
+		// Populate CKs and CKr with sharedKey so that both parties could send and receive
+		// messages from the very beginning.
+		SendCh:     kdfChain{CK: sharedKey, Crypto: c},
+		RecvCh:     kdfChain{CK: sharedKey, Crypto: c},
+		MkSkipped:  &KeysStorageInMemory{},
+		MaxSkip:    1000,
+		MaxKeep:    100,
+		DeleteKeys: make(map[uint]Key),
+	}
+}
+
+func (s *State) applyOptions(opts []option) error {
 	for i := range opts {
-		if err := opts[i](&s); err != nil {
-			return state{}, fmt.Errorf("failed to apply option: %s", err)
+		if err := opts[i](s); err != nil {
+			return fmt.Errorf("failed to apply option: %s", err)
 		}
+	}
+	return nil
+}
+
+func newState(sharedKey Key, opts ...option) (State, error) {
+	if sharedKey == [32]byte{} {
+		return State{}, fmt.Errorf("sharedKey mustn't be empty")
+	}
+
+	s := DefaultState(sharedKey)
+	err := s.applyOptions(opts)
+	if err != nil {
+		return State{}, err
 	}
 
 	return s, nil
 }
 
 // dhRatchet performs a single ratchet step.
-func (s *state) dhRatchet(m MessageHeader) error {
+func (s *State) dhRatchet(m MessageHeader) error {
 	s.PN = s.SendCh.N
 	s.DHr = m.DH
 	s.HKs = s.NHKs
@@ -105,7 +116,7 @@ type skippedKey struct {
 }
 
 // skipMessageKeys skips message keys in the current receiving chain.
-func (s *state) skipMessageKeys(key Key, until uint) ([]skippedKey, error) {
+func (s *State) skipMessageKeys(key Key, until uint) ([]skippedKey, error) {
 	if until < uint(s.RecvCh.N) {
 		return nil, fmt.Errorf("bad until: probably an out-of-order message that was deleted")
 	}
@@ -129,18 +140,31 @@ func (s *state) skipMessageKeys(key Key, until uint) ([]skippedKey, error) {
 	return skipped, nil
 }
 
-func (s *state) applyChanges(sc state, skipped []skippedKey) {
+func (s *State) applyChanges(sc State, skipped []skippedKey) error {
+	var err error
 	*s = sc
 	for _, skipped := range skipped {
-		s.MkSkipped.Put(skipped.key, skipped.nr, skipped.mk)
+		err = s.MkSkipped.Put(skipped.key, skipped.nr, skipped.mk)
+		if err != nil {
+			return err
+		}
 	}
+
+	return nil
 }
 
-func (s *state) deleteSkippedKeys(key Key) {
+func (s *State) deleteSkippedKeys(key Key) error {
+	var err error
+
 	s.DeleteKeys[s.Step] = key
 	s.Step++
 	if hk, ok := s.DeleteKeys[s.Step-s.MaxKeep]; ok {
-		s.MkSkipped.DeletePk(hk)
+		err = s.MkSkipped.DeletePk(hk)
+		if err != nil {
+			return err
+		}
+
 		delete(s.DeleteKeys, s.Step-s.MaxKeep)
 	}
+	return err
 }

--- a/state.go
+++ b/state.go
@@ -85,8 +85,7 @@ func newState(sharedKey Key, opts ...option) (State, error) {
 	}
 
 	s := DefaultState(sharedKey)
-	err := s.applyOptions(opts)
-	if err != nil {
+	if err := s.applyOptions(opts); err != nil {
 		return State{}, err
 	}
 
@@ -141,11 +140,9 @@ func (s *State) skipMessageKeys(key Key, until uint) ([]skippedKey, error) {
 }
 
 func (s *State) applyChanges(sc State, skipped []skippedKey) error {
-	var err error
 	*s = sc
 	for _, skipped := range skipped {
-		err = s.MkSkipped.Put(skipped.key, skipped.nr, skipped.mk)
-		if err != nil {
+		if err := s.MkSkipped.Put(skipped.key, skipped.nr, skipped.mk); err != nil {
 			return err
 		}
 	}
@@ -154,17 +151,15 @@ func (s *State) applyChanges(sc State, skipped []skippedKey) error {
 }
 
 func (s *State) deleteSkippedKeys(key Key) error {
-	var err error
 
 	s.DeleteKeys[s.Step] = key
 	s.Step++
 	if hk, ok := s.DeleteKeys[s.Step-s.MaxKeep]; ok {
-		err = s.MkSkipped.DeletePk(hk)
-		if err != nil {
+		if err := s.MkSkipped.DeletePk(hk); err != nil {
 			return err
 		}
 
 		delete(s.DeleteKeys, s.Step-s.MaxKeep)
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
I have changed the implementation to support saving/storing state.

The changes made:

* `state` is now public `State`. This is because any implementation of the interface need to be able to access it to restore it.
* `New` and `NewWithRemote` take now an `id` of the session and an implementation of `SessionStorage`, (or `nil` if in memory only). State will be saved after each successful step.
* Added public method `Load` to `session` which loads a session from the session storage.