### PR TITLE
Change handling of skipped/deleted keys

### DIFF
--- a/keys_storage_test.go
+++ b/keys_storage_test.go
@@ -29,7 +29,7 @@ func TestKeysStorageInMemory_Put(t *testing.T) {
 	ks := &KeysStorageInMemory{}
 
 	// Act and assert.
-	err := ks.Put(pubKey1, 0, mk)
+	err := ks.Put([]byte("session-id"), pubKey1, 0, mk, 1)
 	require.NoError(t, err)
 }
 
@@ -58,15 +58,9 @@ func TestKeysStorageInMemory_Flow(t *testing.T) {
 	// Arrange.
 	ks := &KeysStorageInMemory{}
 
-	t.Run("delete non-existent pubkey", func(t *testing.T) {
-		// Act and assert.
-		err := ks.DeletePk(pubKey1)
-		require.NoError(t, err)
-	})
-
 	t.Run("put and get existing", func(t *testing.T) {
 		// Act.
-		err := ks.Put(pubKey1, 0, mk)
+		err := ks.Put([]byte("session-id"), pubKey1, 0, mk, 1)
 		require.NoError(t, err)
 
 		k, ok, err := ks.Get(pubKey1, 0)
@@ -137,33 +131,5 @@ func TestKeysStorageInMemory_Flow(t *testing.T) {
 		// Assert.
 		require.NoError(t, err)
 		require.EqualValues(t, 0, cnt)
-	})
-
-	t.Run("delete existing pubkey", func(t *testing.T) {
-		// Act.
-		err := ks.Put(pubKey1, 0, mk)
-		require.NoError(t, err)
-
-		err = ks.Put(pubKey2, 0, mk)
-		require.NoError(t, err)
-
-		err = ks.DeletePk(pubKey1)
-		require.NoError(t, err)
-
-		err = ks.DeletePk(pubKey1)
-		require.NoError(t, err)
-
-		err = ks.DeletePk(pubKey2)
-		require.NoError(t, err)
-
-		cn1, err := ks.Count(pubKey1)
-		require.NoError(t, err)
-
-		cn2, err := ks.Count(pubKey2)
-		require.NoError(t, err)
-
-		// Assert.
-		require.Empty(t, cn1)
-		require.Empty(t, cn2)
 	})
 }

--- a/options.go
+++ b/options.go
@@ -17,7 +17,7 @@ func WithMaxSkip(n int) option {
 	}
 }
 
-// WithMaxKeep specifies the maximum number of ratchet steps before a message is deleted.
+// WithMaxKeep specifies how long we keep message keys, counted in number of messages received
 // nolint: golint
 func WithMaxKeep(n int) option {
 	return func(s *State) error {
@@ -25,6 +25,18 @@ func WithMaxKeep(n int) option {
 			return fmt.Errorf("n must be non-negative")
 		}
 		s.MaxKeep = uint(n)
+		return nil
+	}
+}
+
+// WithMaxMessageKeysPerSession specifies the maximum number of message keys per session
+// nolint: golint
+func WithMaxMessageKeysPerSession(n int) option {
+	return func(s *State) error {
+		if n < 0 {
+			return fmt.Errorf("n must be non-negative")
+		}
+		s.MaxMessageKeysPerSession = n
 		return nil
 	}
 }

--- a/session.go
+++ b/session.go
@@ -115,6 +115,9 @@ func (s *sessionState) RatchetDecrypt(m Message, ad []byte) ([]byte, error) {
 			return nil, fmt.Errorf("can't decrypt skipped message: %s", err)
 		}
 		_ = s.MkSkipped.DeleteMk(m.Header.DH, uint(m.Header.N))
+		if err := s.store(); err != nil {
+			return nil, err
+		}
 		return plaintext, nil
 	}
 
@@ -127,7 +130,6 @@ func (s *sessionState) RatchetDecrypt(m Message, ad []byte) ([]byte, error) {
 	)
 
 	// Is there a new ratchet key?
-	isDHStepped := false
 	if m.Header.DH != sc.DHr {
 		if skippedKeys1, err = sc.skipMessageKeys(sc.DHr, uint(m.Header.PN)); err != nil {
 			return nil, fmt.Errorf("can't skip previous chain message keys: %s", err)
@@ -135,7 +137,6 @@ func (s *sessionState) RatchetDecrypt(m Message, ad []byte) ([]byte, error) {
 		if err = sc.dhRatchet(m.Header); err != nil {
 			return nil, fmt.Errorf("can't perform ratchet step: %s", err)
 		}
-		isDHStepped = true
 	}
 
 	// After all, update the current chain.
@@ -148,16 +149,12 @@ func (s *sessionState) RatchetDecrypt(m Message, ad []byte) ([]byte, error) {
 		return nil, fmt.Errorf("can't decrypt: %s", err)
 	}
 
-	// Apply changes.
-	if err := s.applyChanges(sc, append(skippedKeys1, skippedKeys2...)); err != nil {
-		return nil, err
-	}
+	// Increment the number of keys
+	sc.KeysCount++
 
-	if isDHStepped {
-		err = s.deleteSkippedKeys(s.DHr)
-		if err != nil {
-			return nil, err
-		}
+	// Apply changes.
+	if err := s.applyChanges(sc, s.id, append(skippedKeys1, skippedKeys2...)); err != nil {
+		return nil, err
 	}
 
 	// Store state

--- a/session_he.go
+++ b/session_he.go
@@ -103,11 +103,8 @@ func (s *sessionHE) RatchetDecrypt(m MessageHE, ad []byte) ([]byte, error) {
 		return nil, fmt.Errorf("can't decrypt: %s", err)
 	}
 
-	if err = s.applyChanges(sc, append(skippedKeys1, skippedKeys2...)); err != nil {
+	if err = s.applyChanges(sc, []byte("FIXME"), append(skippedKeys1, skippedKeys2...)); err != nil {
 		return nil, fmt.Errorf("failed to apply changes: %s", err)
-	}
-	if step {
-		_ = s.deleteSkippedKeys(s.HKr)
 	}
 
 	return plaintext, nil

--- a/state_test.go
+++ b/state_test.go
@@ -45,7 +45,6 @@ func TestNewState_Basic(t *testing.T) {
 
 	require.NotNil(t, s.MkSkipped)
 	require.NotNil(t, s.Crypto)
-	require.NotNil(t, s.DeleteKeys)
 }
 
 func TestNewState_BadSharedKey(t *testing.T) {


### PR DESCRIPTION
The purpose of limiting the number of skipped keys generated is to avoid a dos
attack whereby an attacker would send a large N, forcing the device to
compute all the keys between currentN..N .

Previously the logic for handling skipped keys was:

- If in the current receiving chain there are more than maxSkip keys,
throw an error

This is problematic as in long-lived session dropped/unreceived messages starts
piling up, eventually reaching the threshold (1000 dropped/unreceived
messages).

This logic has been changed to be more inline with signals spec https://signal.org/docs/specifications/doubleratchet/, and now
it is:

- If N is > currentN + maxSkip, throw an error

The purpose of limiting the number of skipped keys stored is to avoid a dos
attack whereby an attacker would force us to store a large number of
keys, filling up our storage.

Previously the logic for handling old keys was:

- Once you have maxKeep ratchet steps, delete any key from
currentRatchet - maxKeep.

This, in combination with the maxSkip implementation, capped the number of stored keys to
maxSkip * maxKeep.

The logic has been changed to:

- Keep a maximum of MaxMessageKeysPerSession

and additionally we delete any key that has a sequence number <
currentSeqNum - maxKeep , as suggested by the signal specs, in order to delete old keys which have not been used.

I have only updated the non-encrypted header session as that's the one we are using, I will update the encrypted header version in a second time.