### PR TITLE
Don't delete key without explicit request

### DIFF
--- a/session_test.go
+++ b/session_test.go
@@ -188,7 +188,7 @@ func TestSession_RatchetDecrypt_CommunicationSkippedMessages(t *testing.T) {
 
 		bobSkippedCount, err = bob.MkSkipped.Count(bob.DHr)
 		require.NoError(t, err)
-		require.EqualValues(t, 1, bobSkippedCount)
+		require.EqualValues(t, 2, bobSkippedCount)
 
 		_, err = bob.RatchetDecrypt(m5, nil) // Too many messages
 		require.NotNil(t, err)


### PR DESCRIPTION
We need to wait for messages to be confirmed before we can actually
delete the message key, otherwise if for whatever reason is not
processed we will be unable to receive it again.

This PR changes the behavior so that keys are not removed as soon as used.